### PR TITLE
Update submodule, add branch=master to .gitmodules

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,4 @@
 [submodule "hu_web/ghu_toolkits"]
 	path = hu_web/ghu_toolkits
 	url = https://github.com/global-humanitarians-unite/ghu_toolkits.git
+	branch = master


### PR DESCRIPTION
To make updating the ghu_toolkits submodule easier, add branch=master to gitmodules. That way, we can update it with

    git submodule update --remote

I think this is easier than trying to keep this submodule up-to-date manually, i.e., updating the commit to which the submodule in this repository points every time we commit to ghu_toolkits, which would require 1 commit here ↔ 1 commit there. That would get pretty ugly, I'd say.

If there are other alternatives, though, please let me know.

And while I'm here, go ahead and update the submodule.