### PR TITLE
ghu_browser/layout: Add bower/ prefix to bowerisms

### DIFF
--- a/ghu_web/ghu_browser/templates/ghu_browser/layout.html
+++ b/ghu_web/ghu_browser/templates/ghu_browser/layout.html
@@ -4,7 +4,7 @@
         <title>{% block title %}{% endblock %} — Global Humanitarians Unite</title>
         <meta name="viewport" content="width=device-width, initial-scale=1">
         <link href="{% static "/ghu_browser/css/style.css" %}" rel="stylesheet">
-        <link href="{% static "/bootstrap/dist/css/bootstrap.min.css" %}" rel="stylesheet">
+        <link href="{% static "/bower/bootstrap/dist/css/bootstrap.min.css" %}" rel="stylesheet">
         {% block styles %}{% endblock %}
     </head>
     <body>
@@ -84,8 +84,8 @@
         </div>
 
         {# Scripts #}
-        <script src="{% static "/jquery/dist/jquery.min.js" %}"></script>
-        <script src="{% static "/bootstrap/dist/js/bootstrap.min.js" %}"></script>
+        <script src="{% static "/bower/jquery/dist/jquery.min.js" %}"></script>
+        <script src="{% static "/bower/bootstrap/dist/js/bootstrap.min.js" %}"></script>
         {% block scripts %}{% endblock %}
     </body>
 </html>


### PR DESCRIPTION
Include the prefix bower/... in paths to JavaScript or CSS installed
with bower. This is needed because it's where they live in the static
files directory (otherwise, they're dead links)