### PR TITLE
Remove stray .gitignore reintroduced by 5b304c092b

### DIFF
--- a/ghu_web/ghu_browser/.gitignore
+++ b/ghu_web/ghu_browser/.gitignore
@@ -1,1 +1,0 @@
-static/ghu_browser/bower


### PR DESCRIPTION
In 5b304c092b8b8de5403f341ffc1d84a229a43a50, I reintroduced an outdated
.gitignore removed earlier by Schuyler in
7a414f0081a74fdc689cc843cdd7c25cf5c0eefb, so remove it again.