### PR TITLE
.gitignore: Ignore /ghu_web/common-static/

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,6 @@
 
 # static files
-common-static/*
+/ghu_web/common-static/
 
 # Created by https://www.gitignore.io/api/python,django
 


### PR DESCRIPTION
According to [gitignore(5)](https://www.kernel.org/pub/software/scm/git/docs/gitignore.html), the current line `common-static/*` ignores only files immediately inside a directory named `common-static`:

> Otherwise, Git treats the pattern as a shell glob suitable for
> consumption by fnmatch(3) with the FNM_PATHNAME flag: wildcards in the
> pattern will not match a / in the pathname. For example,
> "Documentation/*.html" matches "Documentation/git.html" but not
> "Documentation/ppc/ppc.html" or "tools/perf/Documentation/perf.html".

So ignore the entire directory instead, and specify its exact location for readability. (The latter comes at the cost of increased fragility, unfortunately)