### PR TITLE
Upgrade pip packages

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,7 @@
 appdirs==1.4.3
-Django==1.10.6
+Django==1.11.1
 packaging==16.8
 pyparsing==2.2.0
+pytz==2017.2
 six==1.10.0
-uWSGI==2.0.14
+uWSGI==2.0.15


### PR DESCRIPTION
I realized we're using an unsupported version of Django, so upgrade to 1.11, [which is an LTS release][1]. This upgrade appears to add a dependency on pytz.

While we're at it, upgrade uWSGI too.

[1]: https://docs.djangoproject.com/en/1.11/releases/1.11/

--------

In requirements.txt, upgrade Django to the latest LTS release and uWSGI
to the latest release.

I did this with:

    $ pip install --upgrade $(cut -f 1 -d = <requirements.txt)
    $ pip freeze >requirements.txt