### PR TITLE
ghu_global: Register User model with admin

### DIFF
--- a/ghu_web/ghu_global/admin.py
+++ b/ghu_web/ghu_global/admin.py
@@ -1,3 +1,5 @@
 from django.contrib import admin
+from django.contrib.auth.admin import UserAdmin
+from .models import User
 
-# Register your models here.
+admin.site.register(User, UserAdmin)


### PR DESCRIPTION
To make the User model show up in the Django admin, register it with the
admin.