### PR TITLE
ghu_global: For admin, specify verbose app name

### DIFF
--- a/ghu_web/ghu_global/__init__.py
+++ b/ghu_web/ghu_global/__init__.py
@@ -1,0 +1,1 @@
+default_app_config = 'ghu_global.apps.GhuGlobalConfig'

--- a/ghu_web/ghu_global/apps.py
+++ b/ghu_web/ghu_global/apps.py
@@ -3,3 +3,4 @@ from django.apps import AppConfig
 
 class GhuGlobalConfig(AppConfig):
     name = 'ghu_global'
+    verbose_name = 'GHU (Global)'


### PR DESCRIPTION
Specify a verbose app name of "GHU (Global)," which will show up in the
admin instead of "Ghu_global."