### PR TITLE
ghu_global/style.css: Make nav responsive again

### DIFF
--- a/ghu_web/ghu_global/static/ghu_global/css/style.css
+++ b/ghu_web/ghu_global/static/ghu_global/css/style.css
@@ -60,7 +60,10 @@ nav a:hover {
 }
 
 @media (max-width: 500px) {
-    nav a {
+    /* Specifying `header' here is a hack to override the inline
+           <style>nav a { width: X%; }</style>
+       in base.html templates in apps */
+    header nav a {
         display: block;
         width: 100%;
     }


### PR DESCRIPTION
464b549cce in ghu_main and d853fd7e72 in ghu_toolkits introduced an
inline <style> element to templates that broke a width<=500px rule for
nav in style.css, so use some CSS-fu to make the rule in style.css take
priority.