### PR TITLE
generate_key: Don't append a [secret] section if one already exists

### DIFF
--- a/ghu_web/generate_key.py
+++ b/ghu_web/generate_key.py
@@ -13,35 +13,46 @@ import os
 import os.path
 from shutil import copyfile
 
-population = string.ascii_letters + string.punctuation + string.digits
-key_len = 512
-
-# If user supplies first argument, use it as the path to the config.ini to
-# write to, else use 'config.ini' in the current directory
-if len(sys.argv) - 1 >= 1:
-    config_ini_path = sys.argv[1]
-else:
-    config_ini_path = 'config.ini'
-print("Writing secret key to "
-      "ini file `{}'...".format(os.path.abspath(config_ini_path)))
-
-print('Generating key...')
-random_bytes = os.urandom(key_len)
-# Work through the random data from /dev/urandom byte by byte, converting it to
-# characters from population
-key = ''.join(population[int(x / 256 * len(population))] for x in random_bytes)
-secrets_section = """
+POPULATION = string.ascii_letters + string.punctuation + string.digits
+KEY_LEN = 512
+SECRETS_SECTION = """
 [secrets]
 secret_key = {}
-""".format(key)
+"""
 
-if not os.path.exists(config_ini_path):
-    print("`{}' does not exist, so copying over "
-          "config.example.ini...".format(config_ini_path))
-    copyfile('config.example.ini', config_ini_path)
+def main(argv):
+    """
+    Generate a Django SECRET_KEY and append it as a [secrets] section to
+    a config.ini.
+    """
 
-print("Appending [secrets] section with key to "
-      "`{}'...".format(config_ini_path))
-open(config_ini_path, 'a').write(secrets_section)
+    # If user supplies first argument, use it as the path to the config.ini to
+    # write to, else use 'config.ini' in the current directory
+    if len(argv) - 1 >= 1:
+        config_ini_path = argv[1]
+    else:
+        config_ini_path = 'config.ini'
+    print("Writing secret key to "
+          "ini file `{}'...".format(os.path.abspath(config_ini_path)))
 
-print('SECRET_KEY generation Done!')
+    print('Generating key...')
+    random_bytes = os.urandom(KEY_LEN)
+    # Work through the random data from /dev/urandom byte by byte, converting it to
+    # characters from POPULATION
+    key = ''.join(POPULATION[int(x / 256 * len(POPULATION))] for x in random_bytes)
+    secrets_section = SECRETS_SECTION.format(key)
+
+    if not os.path.exists(config_ini_path):
+        print("`{}' does not exist, so copying over "
+              "config.example.ini...".format(config_ini_path))
+        copyfile('config.example.ini', config_ini_path)
+
+    print("Appending [secrets] section with key to "
+          "`{}'...".format(config_ini_path))
+    open(config_ini_path, 'a').write(secrets_section)
+
+    print('SECRET_KEY generation Done!')
+    return 0
+
+if __name__ == '__main__':
+    sys.exit(main(sys.argv))

--- a/ghu_web/generate_key.py
+++ b/ghu_web/generate_key.py
@@ -11,6 +11,7 @@ import string
 import sys
 import os
 import os.path
+from configparser import ConfigParser
 from shutil import copyfile
 
 POPULATION = string.ascii_letters + string.punctuation + string.digits
@@ -42,7 +43,18 @@ def main(argv):
     key = ''.join(POPULATION[int(x / 256 * len(POPULATION))] for x in random_bytes)
     secrets_section = SECRETS_SECTION.format(key)
 
-    if not os.path.exists(config_ini_path):
+    if os.path.exists(config_ini_path):
+        cfg = ConfigParser(interpolation=None)
+        if not cfg.read(config_ini_path):
+            print("`{}' exists, but couldn't parse it. Is it a directory or "
+                  "something?".format(config_ini_path))
+            return 1
+        # Assume that every secrets section has a secret_key=
+        if 'secrets' in cfg:
+            print("`{}' exists and already has a [secrets] section. Don't "
+                  "need to do anything, so exiting...".format(config_ini_path))
+            return 0
+    else:
         print("`{}' does not exist, so copying over "
               "config.example.ini...".format(config_ini_path))
         copyfile('config.example.ini', config_ini_path)

--- a/ghu_web/generate_key.py
+++ b/ghu_web/generate_key.py
@@ -44,6 +44,8 @@ def main(argv):
     secrets_section = SECRETS_SECTION.format(key)
 
     if os.path.exists(config_ini_path):
+        # Need to disable interpolation so that `%'s in the secret_key don't
+        # confuse the parser, which will try to treat them as %(interpolation)s
         cfg = ConfigParser(interpolation=None)
         if not cfg.read(config_ini_path):
             print("`{}' exists, but couldn't parse it. Is it a directory or "

--- a/ghu_web/ghu_web/settings.py
+++ b/ghu_web/ghu_web/settings.py
@@ -14,6 +14,8 @@ from configparser import ConfigParser
 # Build paths inside the project like this: os.path.join(BASE_DIR, ...)
 BASE_DIR = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 
+# Need to disable interpolation so that `%'s in the secret_key don't
+# confuse the parser, which will try to treat them as %(interpolation)s
 cfg = ConfigParser(interpolation=None)
 # Preserve case
 cfg.optionxform = str


### PR DESCRIPTION
Currently, if you call generate_key.py on a config.ini which already has
a [secrets] section, it will append another, causing a cryptic error
when you try to `runserver`. So if the .ini exists, parse it to check
that it doesn't already have a [secrets] section before adding one.

Fixes issue #53.