### PR TITLE
Stop routing every URL to the about view

### DIFF
--- a/ghu_web/ghu_main/urls.py
+++ b/ghu_web/ghu_main/urls.py
@@ -9,5 +9,5 @@ urlpatterns = [
     # url('^orgs/$', views.orgs, name='orgs'),
     # url('^forum/$', views.forum, name='forum'),
 
-    url('$', views.about, name='home')
+    url('^$', views.about, name='home')
 ]


### PR DESCRIPTION
A typo in 8e4bd63d accidentally made every URL go to the about page, so
make only / go to the about page.