### PR TITLE
ghu_global/layout.html: Add admin panel link to footer

### DIFF
--- a/ghu_web/ghu_global/templates/ghu_global/layout.html
+++ b/ghu_web/ghu_global/templates/ghu_global/layout.html
@@ -17,7 +17,7 @@
             {% block header %}{% endblock %}
         </header>
         <div id="content">{% block content %}{% endblock %}</div>
-        <div id="footer">&copy; 2017 Global Humanitarians Unite &mdash; <a href="https://github.com/global-humanitarians-unite/ghu">Source code</a></div>
+        <div id="footer">&copy; 2017 Global Humanitarians Unite &mdash; <a href="{% url 'admin:index' %}">Administration panel</a> &mdash; <a href="https://github.com/global-humanitarians-unite/ghu">Source code</a></div>
 
         {# Account modals #}
         <div id="login-modal" class="modal fade" tabindex="-1" role="dialog">


### PR DESCRIPTION
Add a link in the footer to the Django Admin. This way we can click it
in the demo instead of jumping to or typing in the URL.