### PR TITLE
config.deploy-example.ini: Make postgres example use tcp+password

### DIFF
--- a/deploy/config.deploy-example.ini
+++ b/deploy/config.deploy-example.ini
@@ -9,11 +9,11 @@
 
 ; PostgreSQL
 engine = postgresql
-;; All of the rest of these are optional
-;name = ghu
-;user = ghu
-;password = hunter2
-;host = localhost
+; All of the rest of these are optional
+name = ghu
+user = ghu
+password = hunter2
+host = localhost
 ;port = 5432
 
 [production]


### PR DESCRIPTION
For the reasons that will I'll outline in /deploy/README.md, to make
your life easy, you need to use a TCP connection to postgres with a
username/password in the config file. So make the default deploy config
file use a username, password, and provide a hostname.