### PR TITLE
deploy/fresh_checkout.sh: Pass --no-input to manage.py migrate

### DIFF
--- a/deploy/fresh_checkout.sh
+++ b/deploy/fresh_checkout.sh
@@ -25,5 +25,6 @@ ln -sv "$deploy_root/config.ini" ghu_web/config.ini
 pip install -r requirements.txt
 pip install -r deploy/requirements.txt
 cd "$worktree/ghu_web"
-python manage.py migrate
+# Pass --no-input since this might be running as a non-interactive Jenkins job
+python manage.py migrate --no-input
 python manage.py collectstatic


### PR DESCRIPTION
Because Jenkins will be running `python manage.py migrate', not a human,
tell Django not to ask for interactive user input.