### PR TITLE
Page admin: Actually fix #75

### DIFF
--- a/ghu_web/ghu_global/static/admin/js/checkbox_blanker.js
+++ b/ghu_web/ghu_global/static/admin/js/checkbox_blanker.js
@@ -6,6 +6,9 @@
         if (checkbox.prop('checked')) {
             target.prop('disabled', true);
             target.data('old_value', target.val());
+            // Hack to disable Django prepopulation
+            target.data('old_changed', target.data('_changed'));
+            target.data('_changed', true);
             target.val('');
         } else {
             target.prop('disabled', false);
@@ -13,7 +16,13 @@
             // box was blank
             if (target.data('old_value') === '') {
                 source.change();
+                // Always re-enable Django prepopulation if the old value was
+                // blank
+                target.data('_changed', false);
             } else {
+                // Restore the disabled-ness of Django prepopulation from
+                // before they checked the box
+                target.data('_changed', target.data('old_changed'));
                 target.val(target.data('old_value'));
             }
         }


### PR DESCRIPTION
When the 'Make homepage' box is checked, don't prepopulate the slug
field.