### PR TITLE
checkbox_blanker: Monitor checkbox with onchange

### DIFF
--- a/ghu_web/ghu_global/static/admin/js/checkbox_blanker.js
+++ b/ghu_web/ghu_global/static/admin/js/checkbox_blanker.js
@@ -50,7 +50,7 @@
 
             // When the checkbox changes checkedness, disable or re-enable the
             // target field
-            checkbox.on('input', function () {
+            checkbox.on('change', function () {
                 emptyTarget(checkbox, target, source);
             });
 


### PR DESCRIPTION
Listen for the `onchange' event for the 'Make homepage' checkbox, not
the `oninput' event. According to the [spec](https://developer.mozilla.org/en-US/docs/Web/Events/input) supposedly, oninput only
fires for changes to the input attribute, but checking/unchecking the
'Make homepage' checkbox actually changes only the checked attribute.

This happened in Chrome but not Firefox. Thanks to Sun for finding this!