### PR TITLE
Make full-text orgsearch work on all DBs, not just postgres

### DIFF
--- a/ghu_web/ghu_main/views.py
+++ b/ghu_web/ghu_main/views.py
@@ -21,7 +21,7 @@ def page(request, slug=None):
 def organizations(request):
     form = SearchForm(request.GET)
     form.is_valid()
-    context = {'organizations': OrgProfile.objects.filter(name__search = form.cleaned_data['search_terms']),
+    context = {'organizations': OrgProfile.objects.search(form.cleaned_data['search_terms']),
                 'form': form,
                 'navbar': NavbarEntry.objects.all()}
     return render(request, 'ghu_main/organizations.html', context)

--- a/ghu_web/ghu_web/settings.py
+++ b/ghu_web/ghu_web/settings.py
@@ -62,7 +62,6 @@ INSTALLED_APPS = [
     'django.contrib.admin',
     'django.contrib.auth',
     'django.contrib.contenttypes',
-    'django.contrib.postgres',
     'django.contrib.sessions',
     'django.contrib.messages',
     'django.contrib.staticfiles',
@@ -111,6 +110,13 @@ WSGI_APPLICATION = 'ghu_web.wsgi.application'
 if cfg['db']['engine'] == 'sqlite3' and 'name' in cfg['db'] \
                                     and not os.path.isabs(cfg['db']['name']):
     cfg['db']['name'] = os.path.join(BASE_DIR, cfg['db']['name'])
+
+# Currently, only postgres has full text search
+if cfg['db']['engine'] == 'postgresql':
+    INSTALLED_APPS.append('django.contrib.postgres')
+    HAS_FULL_TEXT_SEARCH = True
+else:
+    HAS_FULL_TEXT_SEARCH = False
 
 DATABASES = {
     'default': {


### PR DESCRIPTION
Because a lot of team members use sqlite in development, don't require
postgres for each least some orgsearch to work.